### PR TITLE
Update to Python 3.5 for Bandersnatch 2.0 support

### DIFF
--- a/pypi-mirror/bandersnatch/Dockerfile
+++ b/pypi-mirror/bandersnatch/Dockerfile
@@ -4,22 +4,22 @@ MAINTAINER Jan Losinski <losinski@wh2.tu-dresden.de>
 
 RUN apt-get update && \
 	apt-get -y install --no-install-recommends \
-		virtualenv \
-		python-dev \
+		python3-dev \
 		ca-certificates \
-		python-pip \
+		python3-pip \
 	&& \
 	apt-get clean && \
-	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+        pip3 install --upgrade virtualenv
 
 RUN groupadd user && \
 	useradd --uid 1000 --create-home --home-dir /home/user -g user user
 
 WORKDIR /home/user
 
-RUN su user -c "virtualenv ./bandersnatch-env  && \
+RUN su user -c "/usr/local/bin/virtualenv ./bandersnatch-env  && \
 		. ./bandersnatch-env/bin/activate && \
-		pip install -r https://bitbucket.org/pypa/bandersnatch/raw/stable/requirements.txt"
+		pip3 install -r https://bitbucket.org/pypa/bandersnatch/raw/stable/requirements.txt"
 
 COPY default.conf /etc/bandersnatch.conf
 RUN chown user:user /etc/bandersnatch.conf

--- a/pypi-mirror/bandersnatch/Dockerfile
+++ b/pypi-mirror/bandersnatch/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 MAINTAINER Jan Losinski <losinski@wh2.tu-dresden.de>
 


### PR DESCRIPTION
Issue:
The currently published Docker container (https://hub.docker.com/r/janlo/pypi-mirror-bandersnatch/) doesn't start

```
Traceback (most recent call last):
  File "/home/user/bandersnatch-env/bin/bandersnatch", line 11, in <module>
    load_entry_point('bandersnatch==2.0.0', 'console_scripts', 'bandersnatch')()
  File "/home/user/bandersnatch-env/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 561, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/user/bandersnatch-env/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2631, in load_entry_point
    return ep.load()
  File "/home/user/bandersnatch-env/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2291, in load
    return self.resolve()
  File "/home/user/bandersnatch-env/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2297, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/user/bandersnatch-env/local/lib/python2.7/site-packages/bandersnatch/main.py", line 4, in <module>
    import bandersnatch.mirror
  File "/home/user/bandersnatch-env/local/lib/python2.7/site-packages/bandersnatch/mirror.py", line 1, in <module>
    from .package import Package
  File "/home/user/bandersnatch-env/local/lib/python2.7/site-packages/bandersnatch/package.py", line 4, in <module>
    from urllib.parse import urlparse, unquote
ImportError: No module named parse
```

Cause:
https://pypi.python.org/pypi/bandersnatch#id1

2.0.0 (2017-04-05)
>Official support starts with Python 3.5 but might get away with using an earlier version of Python 3 (maybe 3.3 or so). However, we plan to start using Python 3.5 features (like asyncio) in the near future, so please be advised that running with an older version of Python 3 is not a supported option for the long term.

